### PR TITLE
Account for unused 286, 287 length codes in blocks with fixed huffman…

### DIFF
--- a/decompress.py
+++ b/decompress.py
@@ -116,7 +116,7 @@ def inflate_block_fixed_huffman(stream, out_data):
 		bl_list.append(9) 
 	for i in range(256, 280):
 		bl_list.append(7)
-	for i in range(280, 286):
+	for i in range(280, 288):
 		bl_list.append(8) 
 	literal_length_tree = huffman_tree_from_alphabet_and_bl_list(range(286), bl_list)
 


### PR DESCRIPTION
… codes

As per the specification:

>  Literal/length values 286-287 will never actually
    occur in the compressed data, but participate in the code
    construction.

Their bit lengths must be accounted for, because otherwise the 9-bit codes are off-by-two (literal bytes 144-255).

This can be tested by trying to decompress a byte which is bigger than 144. Without this fix it looks like this:

```
INPUT DATA:
b'\xc4' 

OUTPUT DATA:
b'\xc8'
```
When it is applied, the output and input data match. 

PS. I am trying to implement my own zlib decompressor, and I was using yours for reference, as it is easy to add random `prints()` in Python code.  Finding this bug was quite the learning experience :D 

